### PR TITLE
bugFix/area-page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,10 +19,10 @@
         "react": "^18.2.0",
         "react-bootstrap": "^2.10.2",
         "react-dom": "^18.2.0",
-        "react-router-dom": "^6.22.3",
-        "zustand": "^4.5.2",
         "react-kakao-maps-sdk": "^1.1.26",
-        "react-multi-carousel": "^2.8.5"
+        "react-multi-carousel": "^2.8.5",
+        "react-router-dom": "^6.22.3",
+        "zustand": "^4.5.2"
       },
       "devDependencies": {
         "@types/react": "^18.2.66",

--- a/src/store/area/index.js
+++ b/src/store/area/index.js
@@ -11,7 +11,7 @@ export const useAreaStore = create((set) => ({
   area: initialArea,
   setAreaCode: (areaCode, name, totalCount) =>
     set(
-      (state) => (state.area = { ...state.area, areaCode, name, totalCount })
+      (state) => (state.area = { areaCode, name, sigunguCode: '1', totalCount })
     ),
   setSigunguCode: (sigunguCode) =>
     set((state) => (state.area = { ...state.area, sigunguCode })),


### PR DESCRIPTION
carousel에서 도시 선택시 해당 도시에 존재하지 않는 sigunguCode가 전역상태에 저장되어있을 경우 발생하던 버그 수정

closes #11 