### PR TITLE
fix/weather-section

### DIFF
--- a/src/components/WeatherSection/WeatherSection.jsx
+++ b/src/components/WeatherSection/WeatherSection.jsx
@@ -53,7 +53,7 @@ export default function WeatherSection() {
   }
 
   if (data) {
-    const itemsArray = data?.response.body.items.item;
+    const itemsArray = data.response.body.items.item;
 
     const tmpData = itemsArray.filter((row) => row.category === 'TMP');
     const skyData = itemsArray.filter((row) => row.category === 'SKY');
@@ -73,7 +73,7 @@ export default function WeatherSection() {
     } else {
       weatherState = precipitationType[rainType[startIndex].fcstValue];
     }
-    // console.log(tmpData.slice(startIndex, startIndex + 24));
+    // console.log(itemsArray);
 
     content = (
       <section className='forecast-section'>

--- a/src/constants/weather/index.js
+++ b/src/constants/weather/index.js
@@ -1,7 +1,11 @@
 import data from '../../data/forecast_info.json';
 
 export function getXYCoordsBySigunguName(sigunguName) {
-  const foundIndex = data.findIndex((item) => item['2단계'] === sigunguName);
+  const foundIndex = data.findIndex((item) => {
+    if (item['2단계']) {
+      return item['2단계'].includes(sigunguName);
+    }
+  });
   const nX = data[foundIndex]['격자 X'];
   const nY = data[foundIndex]['격자 Y'];
 
@@ -9,6 +13,28 @@ export function getXYCoordsBySigunguName(sigunguName) {
 }
 
 export function getXYCoordsByCityName(cityName) {
+  switch (cityName) {
+    case '충북':
+      cityName = '충청북도';
+      break;
+    case '충남':
+      cityName = '충청남도';
+      break;
+    case '경북':
+      cityName = '경상북도';
+      break;
+    case '경남':
+      cityName = '경상남도';
+      break;
+    case '전북':
+      cityName = '전라북도';
+      break;
+    case '전남':
+      cityName = '전라남도';
+      break;
+    default:
+      cityName;
+  }
   const foundIndex = data.findIndex((item) => item['1단계'].includes(cityName));
   const nX = data[foundIndex]['격자 X'];
   const nY = data[foundIndex]['격자 Y'];


### PR DESCRIPTION
- getXYCoordsByCityName 함수의 input 값이 '경북', '경남', '충북', '충남', '전북', '전남' 일 경우 제대로된 값을 return 받지 못하던 버그 수정.

- getXYCoordsBySigunguName 함수의 파라미터로 '전주시', '고양시' 등의 특정값이 input으로 들어올 경우 제대로된 값을 반환하지 못하던 버그 수정.